### PR TITLE
Try catch and exit if tgtFw is missing

### DIFF
--- a/src/main/java/com/cyberesicg/oscal_cprt/gui/MainGuiFrame.java
+++ b/src/main/java/com/cyberesicg/oscal_cprt/gui/MainGuiFrame.java
@@ -456,7 +456,12 @@ public class MainGuiFrame extends javax.swing.JFrame {
             String srcFw = FwNameResolver.resolve((String)srcFrameworkSelect.getSelectedItem());
             String tgtFw = FwNameResolver.resolve(str);
             System.out.println("this is the string: "+str);
-            if(tgtFw.equals(srcFw)) continue;
+            try {
+                if(tgtFw.equals(srcFw)) continue;
+            } catch (NullPointerException e) {
+                System.out.println("tgtFw " + str + "is missing from toolData.json");
+                System.exit(1);
+            }
             str = FwNameResolver.resolveDisplayName(str);
 
             m.addElement(str);


### PR DESCRIPTION
Added a try catch for the NullPointerException that happens when a framework/document is not included in toolData.json, caused by CPRT database update. The program exits with an error message stating which framework is missing.